### PR TITLE
location2

### DIFF
--- a/data.go
+++ b/data.go
@@ -215,12 +215,23 @@ type Groups struct {
 
 // GroupDetails of a Groups
 type GroupDetails struct {
-	ChannelID   string `dynamo:"ChannelID,omitempty" json:"channelID,omitempty"`
-	Description string `dynamo:"Description,omitempty" json:"description,omitempty"`
-	EndTime     int64  `dynamo:"EndTime,omitempty" json:"endTime,omitempty"`
-	Location    string `dynamo:"Location,omitempty" json:"location,omitempty"`
-	StartTime   int64  `dynamo:"StartTime,omitempty" json:"startTime,omitempty"`
-	Tier        int    `dynamo:"Tier,omitempty" json:"tier,omitempty"`
+	ChannelID   string   `dynamo:"ChannelID,omitempty" json:"channelID,omitempty"`
+	Description string   `dynamo:"Description,omitempty" json:"description,omitempty"`
+	EndTime     int64    `dynamo:"EndTime,omitempty" json:"endTime,omitempty"`
+	Location    string   `dynamo:"Location,omitempty" json:"location,omitempty"`
+	Location2   Location `dynamo:"Location2,omitempty" json:"location2,omitempty"`
+	StartTime   int64    `dynamo:"StartTime,omitempty" json:"startTime,omitempty"`
+	Tier        int      `dynamo:"Tier,omitempty" json:"tier,omitempty"`
+}
+
+// Location of a group
+type Location struct {
+	StreetAddress   string `dynamo:"StreetAddress,omitempty" json:"startTime,omitempty"`
+	ExtendedAddress string `dynamo:"ExtendedAddress,omitempty" json:"extendedAddress,omitempty"`
+	Locality        string `dynamo:"Locality,omitempty" json:"locality,omitempty"`
+	PostalCode      string `dynamo:"PostalCode,omitempty" json:"postalCode,omitempty"`
+	Region          string `dynamo:"Region,omitempty" json:"region,omitempty"`
+	Country         string `dynamo:"Country,omitempty" json:"country,omitempty"`
 }
 
 // GroupCapacity of a Groups


### PR DESCRIPTION
Location2 so that we can ease into using the new location format. I've converted everything in the DB to have this so people can still see the location before we get the go-renee side of things going, when we do we can then we can run a script to delete all the "Location" fields from the DB, rename "Location2" to "Location" and then update RD accordingly.